### PR TITLE
Configure Dependabot to ignore yt-dlp for grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        ignore:
+          - dependency-name: "yt-dlp"


### PR DESCRIPTION
This change modifies the Dependabot configuration to prevent minor and patch updates for the `yt-dlp` dependency from being included in grouped pull requests. This ensures that `yt-dlp` updates will be handled in separate PRs, allowing you to more easily review and manage this specific dependency.