### PR TITLE
Fix: Correct release creation logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ clean:
 	git clean -Xf out/
 
 DATE := $(shell date +%Y.%m.%d)
-EXISTING_TAGS := $(shell gh release list --json tagName -q '.[] | .tagName' | grep '^$(DATE)')
+EXISTING_TAGS := $(shell git tag -l "$(DATE).*")
 
 .PHONY: create-release
 create-release:
 	@N=1; \
-	while echo "$(EXISTING_TAGS)" | grep -q "^$(DATE).$$$${N}"; do \
+	while echo "$(EXISTING_TAGS)" | grep -q -x "$(DATE).$${N}"; do \
 	  N=$$(($$N + 1)); \
 	done; \
-	TAG="$(DATE).$$N"; \
-	echo "Creating GitHub release for tag: $$TAG"; \
-	gh release create $$TAG --generate-notes
+	TAG="$(DATE).$${N}"; \
+	echo "Creating GitHub release for tag: $${TAG}"; \
+	gh release create $${TAG} --generate-notes


### PR DESCRIPTION
The previous implementation of the `create-release` target had several issues:
- It checked for GitHub releases instead of git tags, which could lead to errors if a tag was created but the release failed.
- The `grep` command used for checking existing tags was not using an exact match, which could cause incorrect tag increments (e.g., `.1` matching `.10`).
- Shell variables in the recipe were not properly escaped, leading to incorrect tag generation.

This commit addresses these issues by:
- Using `git tag -l` to check for existing tags.
- Using `grep -x` for exact tag matching.
- Properly escaping shell variables in the `create-release` recipe.
