### PR TITLE
ci: add docker image smoke test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,6 +66,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build image for smoke test (linux/amd64, local load)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          tags: smoke-test-amd64:${{ github.sha }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test (linux/amd64)
+        run: |
+          docker run --rm --entrypoint python smoke-test-amd64:${{ github.sha }} -m slack_youtube_dl_bot --help
+          docker run --rm --entrypoint ffmpeg smoke-test-amd64:${{ github.sha }} -version
+
+      - name: Build image for smoke test (linux/arm64, local load)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          tags: smoke-test-arm64:${{ github.sha }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test (linux/arm64)
+        run: |
+          docker run --rm --entrypoint python smoke-test-arm64:${{ github.sha }} -m slack_youtube_dl_bot --help
+          docker run --rm --entrypoint ffmpeg smoke-test-arm64:${{ github.sha }} -version
+
       - name: Build and push Docker image
         id: build-push-action
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,8 +78,7 @@ jobs:
 
       - name: Smoke test (linux/amd64)
         run: |
-          docker run --rm --platform linux/amd64 --entrypoint python smoke-test-amd64:${{ github.sha }} -m slack_youtube_dl_bot --help
-          docker run --rm --platform linux/amd64 --entrypoint ffmpeg smoke-test-amd64:${{ github.sha }} -version
+          make docker-smoke IMAGE=smoke-test-amd64:${{ github.sha }} PLATFORM=linux/amd64
 
       - name: Build image for smoke test (linux/arm64, local load)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -93,8 +92,7 @@ jobs:
 
       - name: Smoke test (linux/arm64)
         run: |
-          docker run --rm --platform linux/arm64 --entrypoint python smoke-test-arm64:${{ github.sha }} -m slack_youtube_dl_bot --help
-          docker run --rm --platform linux/arm64 --entrypoint ffmpeg smoke-test-arm64:${{ github.sha }} -version
+          make docker-smoke IMAGE=smoke-test-arm64:${{ github.sha }} PLATFORM=linux/arm64
 
       - name: Build and push Docker image
         id: build-push-action

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Smoke test (linux/amd64)
         run: |
-          docker run --rm --entrypoint python smoke-test-amd64:${{ github.sha }} -m slack_youtube_dl_bot --help
-          docker run --rm --entrypoint ffmpeg smoke-test-amd64:${{ github.sha }} -version
+          docker run --rm --platform linux/amd64 --entrypoint python smoke-test-amd64:${{ github.sha }} -m slack_youtube_dl_bot --help
+          docker run --rm --platform linux/amd64 --entrypoint ffmpeg smoke-test-amd64:${{ github.sha }} -version
 
       - name: Build image for smoke test (linux/arm64, local load)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -93,8 +93,8 @@ jobs:
 
       - name: Smoke test (linux/arm64)
         run: |
-          docker run --rm --entrypoint python smoke-test-arm64:${{ github.sha }} -m slack_youtube_dl_bot --help
-          docker run --rm --entrypoint ffmpeg smoke-test-arm64:${{ github.sha }} -version
+          docker run --rm --platform linux/arm64 --entrypoint python smoke-test-arm64:${{ github.sha }} -m slack_youtube_dl_bot --help
+          docker run --rm --platform linux/arm64 --entrypoint ffmpeg smoke-test-arm64:${{ github.sha }} -version
 
       - name: Build and push Docker image
         id: build-push-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ WORKDIR /workdir
 
 RUN apk add --no-cache curl
 
-RUN curl -L https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz | tar -Jxf -
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+      amd64) ffmpeg_flavor="linux64" ;; \
+      arm64) ffmpeg_flavor="linuxarm64" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf -
 
 FROM python:3.10-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ RUN case "${TARGETARCH}" in \
       arm64) ffmpeg_flavor="linuxarm64" ;; \
       *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
-    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - && \
     mkdir -p /workdir/ffmpeg && \
-    mv "/workdir/ffmpeg-master-latest-${ffmpeg_flavor}-gpl/bin" /workdir/ffmpeg/bin
+    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - -C /workdir/ffmpeg --strip-components=1
 
 FROM python:3.10-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /workdir
 
 RUN apk add --no-cache curl
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 RUN case "${TARGETARCH}" in \
       amd64) ffmpeg_flavor="linux64" ;; \
       arm64) ffmpeg_flavor="linuxarm64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN case "${TARGETARCH}" in \
       arm64) ffmpeg_flavor="linuxarm64" ;; \
       *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
-    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf -
+    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - && \
+    mkdir -p /workdir/ffmpeg && \
+    mv "/workdir/ffmpeg-master-latest-${ffmpeg_flavor}-gpl" /workdir/ffmpeg
 
 FROM python:3.10-slim
 
@@ -28,7 +30,7 @@ RUN groupadd -g 1000 appgroup && \
 
 WORKDIR /workdir
 
-COPY --from=ffmpeg-downloader /workdir/ffmpeg-master-latest-linux64-gpl/bin /usr/local/bin
+COPY --from=ffmpeg-downloader /workdir/ffmpeg/bin /usr/local/bin
 
 COPY --from=builder /workdir/.venv /workdir/.venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN case "${TARGETARCH}" in \
       *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
     mkdir -p /workdir/ffmpeg && \
-    curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - -C /workdir/ffmpeg --strip-components=1
+    curl -fsSL "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - -C /workdir/ffmpeg --strip-components=1
 
 FROM python:3.10-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:latest AS ffmpeg-downloader
 
 WORKDIR /workdir
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl xz
 
 ARG TARGETARCH=amd64
 RUN case "${TARGETARCH}" in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ WORKDIR /workdir
 
 RUN apk add --no-cache curl xz
 
-ARG TARGETARCH=amd64
-RUN case "${TARGETARCH}" in \
+ARG TARGETARCH
+RUN arch="${TARGETARCH:-amd64}" && \
+    case "$arch" in \
       amd64) ffmpeg_flavor="linux64" ;; \
       arm64) ffmpeg_flavor="linuxarm64" ;; \
-      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+      *) echo "Unsupported TARGETARCH: $arch" >&2; exit 1 ;; \
     esac && \
     mkdir -p /workdir/ffmpeg && \
     curl -fsSL "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - -C /workdir/ffmpeg --strip-components=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN case "${TARGETARCH}" in \
     esac && \
     curl -L "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-${ffmpeg_flavor}-gpl.tar.xz" | tar -Jxf - && \
     mkdir -p /workdir/ffmpeg && \
-    mv "/workdir/ffmpeg-master-latest-${ffmpeg_flavor}-gpl" /workdir/ffmpeg
+    mv "/workdir/ffmpeg-master-latest-${ffmpeg_flavor}-gpl/bin" /workdir/ffmpeg/bin
 
 FROM python:3.10-slim
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,39 @@
 clean:
 	git clean -Xf out/
 
+.PHONY: docker-smoke
+docker-smoke:
+	@test -n "$(IMAGE)" || (echo "ERROR: IMAGE is required (e.g. IMAGE=slack-youtube-dl-bot:dev)" >&2; exit 1)
+	@set -e; \
+	PLATFORM="$${PLATFORM:-}"; \
+	if [ -n "$$PLATFORM" ]; then \
+	  platform_flag="--platform $$PLATFORM"; \
+	else \
+	  platform_flag=""; \
+	fi; \
+	echo "Smoke testing $$IMAGE ($${PLATFORM:-native})"; \
+	docker run --rm $$platform_flag --entrypoint python "$(IMAGE)" -m slack_youtube_dl_bot --help >/dev/null; \
+	docker run --rm $$platform_flag --entrypoint ffmpeg "$(IMAGE)" -version >/dev/null; \
+	echo "OK"
+
+.PHONY: docker-build-smoke
+docker-build-smoke:
+	@set -e; \
+	TAG="$${TAG:-local-smoke}"; \
+	PLATFORM="$${PLATFORM:-}"; \
+	if [ -z "$$PLATFORM" ]; then \
+	  echo "ERROR: PLATFORM is required (e.g. PLATFORM=linux/amd64)" >&2; \
+	  exit 1; \
+	fi; \
+	echo "Building $$TAG for $$PLATFORM"; \
+	docker buildx build --load --platform "$$PLATFORM" -t "$$TAG" .; \
+	$(MAKE) docker-smoke IMAGE="$$TAG" PLATFORM="$$PLATFORM"
+
+.PHONY: docker-build-smoke-all
+docker-build-smoke-all:
+	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke-amd64}" PLATFORM=linux/amd64
+	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke-arm64}" PLATFORM=linux/arm64
+
 .PHONY: fmt
 fmt:
 	uv run ruff format .

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ docker-build-smoke:
 
 .PHONY: docker-build-smoke-all
 docker-build-smoke-all:
-	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke-amd64}" PLATFORM=linux/amd64
-	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke-arm64}" PLATFORM=linux/arm64
+	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke}-amd64" PLATFORM=linux/amd64
+	$(MAKE) docker-build-smoke TAG="$${TAG:-local-smoke}-arm64" PLATFORM=linux/arm64
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,22 @@ clean:
 
 .PHONY: docker-smoke
 docker-smoke:
-	@test -n "$(IMAGE)" || (echo "ERROR: IMAGE is required (e.g. IMAGE=slack-youtube-dl-bot:dev)" >&2; exit 1)
+	@if [ -z "$(IMAGE)" ]; then echo "ERROR: IMAGE is required (e.g. IMAGE=slack-youtube-dl-bot:dev)" >&2; exit 1; fi
 	@set -e; \
-	PLATFORM="$${PLATFORM:-}"; \
-	if [ -n "$$PLATFORM" ]; then \
-	  platform_flag="--platform $$PLATFORM"; \
-	else \
-	  platform_flag=""; \
-	fi; \
-	echo "Smoke testing $$IMAGE ($${PLATFORM:-native})"; \
+	platform_flag="$(if $(PLATFORM),--platform $(PLATFORM),)"; \
+	echo "Smoke testing $(IMAGE) ($(if $(PLATFORM),$(PLATFORM),native))"; \
 	docker run --rm $$platform_flag --entrypoint python "$(IMAGE)" -m slack_youtube_dl_bot --help >/dev/null; \
 	docker run --rm $$platform_flag --entrypoint ffmpeg "$(IMAGE)" -version >/dev/null; \
 	echo "OK"
 
 .PHONY: docker-build-smoke
 docker-build-smoke:
+	@if [ -z "$(PLATFORM)" ]; then echo "ERROR: PLATFORM is required (e.g. PLATFORM=linux/amd64)" >&2; exit 1; fi
 	@set -e; \
-	TAG="$${TAG:-local-smoke}"; \
-	PLATFORM="$${PLATFORM:-}"; \
-	if [ -z "$$PLATFORM" ]; then \
-	  echo "ERROR: PLATFORM is required (e.g. PLATFORM=linux/amd64)" >&2; \
-	  exit 1; \
-	fi; \
-	echo "Building $$TAG for $$PLATFORM"; \
-	docker buildx build --load --platform "$$PLATFORM" -t "$$TAG" .; \
-	$(MAKE) docker-smoke IMAGE="$$TAG" PLATFORM="$$PLATFORM"
+	tag="$(if $(TAG),$(TAG),local-smoke)"; \
+	echo "Building $$tag for $(PLATFORM)"; \
+	docker buildx build --load --platform "$(PLATFORM)" -t "$$tag" .; \
+	$(MAKE) docker-smoke IMAGE="$$tag" PLATFORM="$(PLATFORM)"
 
 .PHONY: docker-build-smoke-all
 docker-build-smoke-all:

--- a/slack_youtube_dl_bot/__main__.py
+++ b/slack_youtube_dl_bot/__main__.py
@@ -12,12 +12,15 @@ from slack_youtube_dl_bot.worker import worker
 async def main(n_workers: int):
     logger.debug(f"Start the bot with {n_workers} workers.")
 
+    slack_app_token = os.environ.get("SLACK_APP_TOKEN")
+    slack_bot_token = os.environ.get("SLACK_BOT_TOKEN")
+    if not slack_app_token or not slack_bot_token:
+        raise click.ClickException(
+            "Environment variables SLACK_APP_TOKEN and SLACK_BOT_TOKEN are required."
+        )
+
     # Defer importing Slack app until runtime so `--help` works without env vars.
     from slack_youtube_dl_bot.slack_app import app
-
-    slack_app_token = os.environ.get("SLACK_APP_TOKEN")
-    if not slack_app_token:
-        raise click.ClickException("Environment variable SLACK_APP_TOKEN is required.")
 
     slack_bot = asyncio.create_task(
         AsyncSocketModeHandler(app, slack_app_token).start_async()

--- a/slack_youtube_dl_bot/__main__.py
+++ b/slack_youtube_dl_bot/__main__.py
@@ -6,15 +6,21 @@ from logzero import logger
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
 from slack_youtube_dl_bot.job import job_queue
-from slack_youtube_dl_bot.slack_app import app
 from slack_youtube_dl_bot.worker import worker
 
 
 async def main(n_workers: int):
     logger.debug(f"Start the bot with {n_workers} workers.")
 
+    # Defer importing Slack app until runtime so `--help` works without env vars.
+    from slack_youtube_dl_bot.slack_app import app
+
+    slack_app_token = os.environ.get("SLACK_APP_TOKEN")
+    if not slack_app_token:
+        raise click.ClickException("Environment variable SLACK_APP_TOKEN is required.")
+
     slack_bot = asyncio.create_task(
-        AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"]).start_async()
+        AsyncSocketModeHandler(app, slack_app_token).start_async()
     )
 
     workers = [asyncio.create_task(worker(i)) for i in range(n_workers)]


### PR DESCRIPTION
## Summary
- Run pre-push smoke tests against the built Docker image for both linux/amd64 and linux/arm64.
- Ensure `python -m slack_youtube_dl_bot --help` works without Slack tokens by deferring Slack env access until runtime.
- Verify `ffmpeg` is available in the image.

Made with [Cursor](https://cursor.com)