### PR TITLE
test: add happy-path integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,6 @@ ignore_missing_imports = true
 dev = [
     "mypy>=1.20.2",
     "pytest>=9.0.3",
+    "pytest-asyncio>=1.2.0",
     "ruff>=0.12.0",
 ]

--- a/tests/test_process_message.py
+++ b/tests/test_process_message.py
@@ -1,6 +1,21 @@
-import pytest
+import asyncio
 
-from slack_youtube_dl_bot.process_message import extract_url_from_message_text
+import pytest
+from slack_bolt.context.say.async_say import AsyncSay
+
+from slack_youtube_dl_bot.process_message import (
+    extract_url_from_message_text,
+    process_message,
+)
+
+
+class _RecordingSay(AsyncSay):
+    def __init__(self):
+        super().__init__(client=None, channel="C_TEST", thread_ts=None)
+        self.calls: list[dict] = []
+
+    async def __call__(self, text="", thread_ts=None, **kwargs):
+        self.calls.append({"text": text, "thread_ts": thread_ts, "kwargs": kwargs})
 
 
 @pytest.mark.parametrize(
@@ -23,3 +38,25 @@ from slack_youtube_dl_bot.process_message import extract_url_from_message_text
 )
 def test_extract_url_from_message_text(text: str, expected: str):
     assert extract_url_from_message_text(text) == expected
+
+
+@pytest.mark.asyncio
+async def test_process_message_happy_path_enqueues_job_and_replies(monkeypatch):
+    queue: asyncio.Queue = asyncio.Queue()
+
+    monkeypatch.setattr("slack_youtube_dl_bot.job.job_queue", queue)
+    monkeypatch.setattr("slack_youtube_dl_bot.process_message.job_queue", queue)
+
+    say = _RecordingSay()
+
+    message = {"text": "<https://example.com/path?query=1>", "ts": "123.456"}
+    await process_message(message=message, say=say)
+
+    job = queue.get_nowait()
+    assert str(job.url) == "https://example.com/path?query=1"
+    assert job.thread_ts == "123.456"
+
+    assert len(say.calls) == 1
+    assert say.calls[0]["thread_ts"] == "123.456"
+    assert "https://example.com/path?query=1" in say.calls[0]["text"]
+    assert "is pushed to the job queue" in say.calls[0]["text"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,73 @@
+import pytest
+from slack_bolt.context.say.async_say import AsyncSay
+
+from slack_youtube_dl_bot.job import Job
+from slack_youtube_dl_bot.worker import process_job
+
+
+class _RecordingSay(AsyncSay):
+    def __init__(self):
+        super().__init__(client=None, channel="C_TEST", thread_ts=None)
+        self.calls: list[dict] = []
+
+    async def __call__(self, text="", thread_ts=None, **kwargs):
+        self.calls.append({"text": text, "thread_ts": thread_ts, "kwargs": kwargs})
+
+
+class _FakeStream:
+    def __init__(self, lines: list[bytes]):
+        self._lines = lines
+        self._idx = 0
+
+    def at_eof(self) -> bool:
+        return self._idx >= len(self._lines)
+
+    async def readline(self) -> bytes:
+        if self.at_eof():
+            return b""
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line
+
+
+class _FakeProc:
+    def __init__(self, stdout_lines: list[bytes], stderr_lines: list[bytes]):
+        self.stdout = _FakeStream(stdout_lines)
+        self.stderr = _FakeStream(stderr_lines)
+
+    async def communicate(self):
+        return (b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeypatch):
+    say = _RecordingSay()
+    job = Job(url="https://example.com/video", thread_ts="123.456", say=say)
+
+    created: dict = {}
+
+    async def fake_create_subprocess_shell(cmd, stdout=None, stderr=None):
+        created["cmd"] = cmd
+        created["stdout"] = stdout
+        created["stderr"] = stderr
+        return _FakeProc(
+            stdout_lines=[b"hello-stdout\n"], stderr_lines=[b"hello-stderr\n"]
+        )
+
+    async def fake_sleep(_seconds: float):
+        return None
+
+    monkeypatch.setattr(
+        "slack_youtube_dl_bot.worker.asyncio.create_subprocess_shell",
+        fake_create_subprocess_shell,
+    )
+    monkeypatch.setattr("slack_youtube_dl_bot.worker.asyncio.sleep", fake_sleep)
+
+    await process_job(job=job, worker_id=7)
+
+    assert "python -m yt_dlp" in created["cmd"]
+    assert "https://example.com/video" in created["cmd"]
+
+    texts = [c["text"] for c in say.calls]
+    assert "[worker-7] hello-stdout\n" in texts
+    assert "[worker-7] hello-stderr\n" in texts

--- a/uv.lock
+++ b/uv.lock
@@ -176,6 +176,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -949,6 +958,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,6 +1034,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -1028,6 +1052,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.20.2" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "ruff", specifier = ">=0.12.0" },
 ]
 


### PR DESCRIPTION
## Summary
- Add async happy-path integration coverage for message handling and worker subprocess output forwarding.
- Introduce `pytest-asyncio` as a dev dependency to keep async tests declarative and readable.

## Test plan
- `make check`

Made with [Cursor](https://cursor.com)