### PR TITLE
refactor(worker): build yt-dlp argv in one place and run via create_subprocess_exec

### DIFF
--- a/slack_youtube_dl_bot/worker.py
+++ b/slack_youtube_dl_bot/worker.py
@@ -3,6 +3,7 @@ import asyncio
 from logzero import logger
 
 from slack_youtube_dl_bot.job import Job, job_queue
+from slack_youtube_dl_bot.yt_dlp_cmd import build_yt_dlp_cmd
 
 
 async def process_job(job: Job, worker_id: int) -> None:
@@ -10,18 +11,9 @@ async def process_job(job: Job, worker_id: int) -> None:
 
     logger.debug(f"Start downloading {job.url}")
 
-    proc = await asyncio.create_subprocess_shell(
-        " ".join(
-            [
-                "python",
-                "-m",
-                "yt_dlp",
-                "-o",
-                '"/out/%(extractor)s/%(channel)s - %(channel_id)s/%(playlist)s - %(playlist_id)s/%(title)s - %(id)s.%(ext)s"',
-                "--no-progress",
-                f'"{job.url}"',
-            ]
-        ),
+    cmd = build_yt_dlp_cmd(url=str(job.url))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )

--- a/slack_youtube_dl_bot/yt_dlp_cmd.py
+++ b/slack_youtube_dl_bot/yt_dlp_cmd.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Final
 
 _DEFAULT_OUTPUT_TEMPLATE: Final[str] = (
@@ -11,7 +12,7 @@ def build_yt_dlp_cmd(
     *, url: str, output_template: str = _DEFAULT_OUTPUT_TEMPLATE
 ) -> tuple[str, ...]:
     return (
-        "python",
+        sys.executable,
         "-m",
         "yt_dlp",
         "-o",

--- a/slack_youtube_dl_bot/yt_dlp_cmd.py
+++ b/slack_youtube_dl_bot/yt_dlp_cmd.py
@@ -1,0 +1,21 @@
+from typing import Final
+
+_DEFAULT_OUTPUT_TEMPLATE: Final[str] = (
+    "/out/%(extractor)s/%(channel)s - %(channel_id)s/"
+    "%(playlist)s - %(playlist_id)s/"
+    "%(title)s - %(id)s.%(ext)s"
+)
+
+
+def build_yt_dlp_cmd(
+    *, url: str, output_template: str = _DEFAULT_OUTPUT_TEMPLATE
+) -> tuple[str, ...]:
+    return (
+        "python",
+        "-m",
+        "yt_dlp",
+        "-o",
+        output_template,
+        "--no-progress",
+        url,
+    )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from slack_bolt.context.say.async_say import AsyncSay
 
@@ -65,7 +67,7 @@ async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeyp
 
     await process_job(job=job, worker_id=7)
 
-    assert created["cmd"][:3] == ("python", "-m", "yt_dlp")
+    assert created["cmd"][:3] == (sys.executable, "-m", "yt_dlp")
     assert "https://example.com/video" in created["cmd"]
 
     texts = [c["text"] for c in say.calls]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -46,8 +46,8 @@ async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeyp
 
     created: dict = {}
 
-    async def fake_create_subprocess_shell(cmd, stdout=None, stderr=None):
-        created["cmd"] = cmd
+    async def fake_create_subprocess_exec(*cmd, stdout=None, stderr=None):
+        created["cmd"] = tuple(cmd)
         created["stdout"] = stdout
         created["stderr"] = stderr
         return _FakeProc(
@@ -58,14 +58,14 @@ async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeyp
         return None
 
     monkeypatch.setattr(
-        "slack_youtube_dl_bot.worker.asyncio.create_subprocess_shell",
-        fake_create_subprocess_shell,
+        "slack_youtube_dl_bot.worker.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
     )
     monkeypatch.setattr("slack_youtube_dl_bot.worker.asyncio.sleep", fake_sleep)
 
     await process_job(job=job, worker_id=7)
 
-    assert "python -m yt_dlp" in created["cmd"]
+    assert created["cmd"][:3] == ("python", "-m", "yt_dlp")
     assert "https://example.com/video" in created["cmd"]
 
     texts = [c["text"] for c in say.calls]


### PR DESCRIPTION
Introduce a dedicated command builder for yt-dlp and execute it with exec-style subprocess calls. Adjust tests to validate argv rather than a shell command string.

Made-with: Cursor
