### PR TITLE
docs: add agent instructions for using make targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent instructions
+
+## Commands
+
+When running formatting, linting, type checking, or tests in this repository, **use `make` targets instead of invoking the underlying tools directly**.
+
+The single source of truth for the available commands is `Makefile`. If you need a new command, add or update a target there.


### PR DESCRIPTION
Document that formatting, linting, type checking, and tests should be run via Makefile targets so commands stay centralized and consistent.

Made-with: Cursor
