### PR TITLE
feat(worker): buffer subprocess output before posting to Slack

### DIFF
--- a/slack_youtube_dl_bot/worker.py
+++ b/slack_youtube_dl_bot/worker.py
@@ -24,8 +24,9 @@ async def process_job(job: Job, worker_id: int) -> None:
     async def flush_buffer() -> None:
         if not message_buffer:
             return
-        await job.reply("".join(message_buffer))
+        content = "".join(message_buffer)
         message_buffer.clear()
+        await job.reply(content)
 
     if proc.stdout and proc.stderr:
         while True:

--- a/slack_youtube_dl_bot/worker.py
+++ b/slack_youtube_dl_bot/worker.py
@@ -6,6 +6,35 @@ from slack_youtube_dl_bot.job import Job, job_queue
 from slack_youtube_dl_bot.yt_dlp_cmd import build_yt_dlp_cmd
 
 POST_INTERVAL_SECONDS = 10.0
+SLACK_MESSAGE_CHAR_LIMIT = 4000
+
+
+def chunk_output_lines(
+    lines: list[str], max_chars: int = SLACK_MESSAGE_CHAR_LIMIT
+) -> list[str]:
+    chunks: list[str] = []
+    current = ""
+
+    for line in lines:
+        if len(line) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            for idx in range(0, len(line), max_chars):
+                chunks.append(line[idx : idx + max_chars])
+            continue
+
+        if len(current) + len(line) > max_chars:
+            chunks.append(current)
+            current = line
+            continue
+
+        current += line
+
+    if current:
+        chunks.append(current)
+
+    return chunks
 
 
 async def process_job(job: Job, worker_id: int) -> None:
@@ -24,9 +53,10 @@ async def process_job(job: Job, worker_id: int) -> None:
     async def flush_buffer() -> None:
         if not message_buffer:
             return
-        content = "".join(message_buffer)
+        chunks = chunk_output_lines(message_buffer)
         message_buffer.clear()
-        await job.reply(content)
+        for chunk in chunks:
+            await job.reply(chunk)
 
     if proc.stdout and proc.stderr:
         while True:

--- a/slack_youtube_dl_bot/worker.py
+++ b/slack_youtube_dl_bot/worker.py
@@ -5,9 +5,12 @@ from logzero import logger
 from slack_youtube_dl_bot.job import Job, job_queue
 from slack_youtube_dl_bot.yt_dlp_cmd import build_yt_dlp_cmd
 
+POST_INTERVAL_SECONDS = 10.0
+
 
 async def process_job(job: Job, worker_id: int) -> None:
     message_prefix = f"[worker-{worker_id}] "
+    message_buffer: list[str] = []
 
     logger.debug(f"Start downloading {job.url}")
 
@@ -18,6 +21,12 @@ async def process_job(job: Job, worker_id: int) -> None:
         stderr=asyncio.subprocess.PIPE,
     )
 
+    async def flush_buffer() -> None:
+        if not message_buffer:
+            return
+        await job.reply("".join(message_buffer))
+        message_buffer.clear()
+
     if proc.stdout and proc.stderr:
         while True:
             if proc.stdout.at_eof() and proc.stderr.at_eof():
@@ -26,13 +35,16 @@ async def process_job(job: Job, worker_id: int) -> None:
             stdout = (await proc.stdout.readline()).decode()
             if stdout:
                 logger.debug(stdout)
-                await job.reply(message_prefix + stdout)
+                message_buffer.append(message_prefix + stdout)
             stderr = (await proc.stderr.readline()).decode()
             if stderr:
                 logger.debug(stderr)
-                await job.reply(message_prefix + stderr)
+                message_buffer.append(message_prefix + stderr)
 
-            await asyncio.sleep(1)
+            await flush_buffer()
+            await asyncio.sleep(POST_INTERVAL_SECONDS)
+
+        await flush_buffer()
 
     await proc.communicate()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,7 +4,11 @@ import pytest
 from slack_bolt.context.say.async_say import AsyncSay
 
 from slack_youtube_dl_bot.job import Job
-from slack_youtube_dl_bot.worker import POST_INTERVAL_SECONDS, process_job
+from slack_youtube_dl_bot.worker import (
+    POST_INTERVAL_SECONDS,
+    chunk_output_lines,
+    process_job,
+)
 
 
 class _RecordingSay(AsyncSay):
@@ -78,3 +82,19 @@ async def test_process_job_happy_path_posts_buffered_subprocess_output_to_slack(
     texts = [c["text"] for c in say.calls]
     assert texts == ["[worker-7] hello-stdout\n[worker-7] hello-stderr\n"]
     assert sleep_calls == [POST_INTERVAL_SECONDS]
+
+
+def test_chunk_output_lines_prefers_newline_boundaries():
+    lines = ["aaa\n", "bbb\n", "ccc\n"]
+
+    chunks = chunk_output_lines(lines, max_chars=8)
+
+    assert chunks == ["aaa\nbbb\n", "ccc\n"]
+
+
+def test_chunk_output_lines_splits_single_long_line():
+    lines = ["abcdefghij"]
+
+    chunks = chunk_output_lines(lines, max_chars=4)
+
+    assert chunks == ["abcd", "efgh", "ij"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -42,7 +42,9 @@ class _FakeProc:
 
 
 @pytest.mark.asyncio
-async def test_process_job_happy_path_posts_buffered_subprocess_output_to_slack(monkeypatch):
+async def test_process_job_happy_path_posts_buffered_subprocess_output_to_slack(
+    monkeypatch,
+):
     say = _RecordingSay()
     job = Job(url="https://example.com/video", thread_ts="123.456", say=say)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,7 +4,7 @@ import pytest
 from slack_bolt.context.say.async_say import AsyncSay
 
 from slack_youtube_dl_bot.job import Job
-from slack_youtube_dl_bot.worker import process_job
+from slack_youtube_dl_bot.worker import POST_INTERVAL_SECONDS, process_job
 
 
 class _RecordingSay(AsyncSay):
@@ -42,7 +42,7 @@ class _FakeProc:
 
 
 @pytest.mark.asyncio
-async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeypatch):
+async def test_process_job_happy_path_posts_buffered_subprocess_output_to_slack(monkeypatch):
     say = _RecordingSay()
     job = Job(url="https://example.com/video", thread_ts="123.456", say=say)
 
@@ -56,7 +56,10 @@ async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeyp
             stdout_lines=[b"hello-stdout\n"], stderr_lines=[b"hello-stderr\n"]
         )
 
-    async def fake_sleep(_seconds: float):
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float):
+        sleep_calls.append(seconds)
         return None
 
     monkeypatch.setattr(
@@ -71,5 +74,5 @@ async def test_process_job_happy_path_streams_subprocess_output_to_slack(monkeyp
     assert "https://example.com/video" in created["cmd"]
 
     texts = [c["text"] for c in say.calls]
-    assert "[worker-7] hello-stdout\n" in texts
-    assert "[worker-7] hello-stderr\n" in texts
+    assert texts == ["[worker-7] hello-stdout\n[worker-7] hello-stderr\n"]
+    assert sleep_calls == [POST_INTERVAL_SECONDS]


### PR DESCRIPTION
Change worker log posting from per-line immediate sends to buffered interval-based sends, so stdout and stderr events in the same cycle are posted together. This reduces noisy thread chatter and lowers the chance of hitting Slack rate limits, while keeping behavior covered by tests that now assert aggregated message output and interval sleep usage.

Made-with: Cursor
